### PR TITLE
Removed unneeded Permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,7 +43,6 @@
 
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
         </config-file>
 
         <source-file src="src/android/FilePath.java" target-dir="src/com/hiddentao/cordova/filepath"/>


### PR DESCRIPTION
As discussed here, there is no need for the WRITE_EXTERNAL_STORAGE permission:

https://github.com/hiddentao/cordova-plugin-filepath/issues/48